### PR TITLE
Remove already inheriged methods from `Notify::Pipe`

### DIFF
--- a/lib/async/container/notify/pipe.rb
+++ b/lib/async/container/notify/pipe.rb
@@ -82,22 +82,6 @@ module Async
 					send(ready: true, **message)
 				end
 				
-				def restarting!(**message)
-					message[:ready] = false
-					message[:reloading] = true
-					message[:status] ||= "Restarting..."
-					
-					send(**message)
-				end
-				
-				def reloading!(**message)
-					message[:ready] = false
-					message[:reloading] = true
-					message[:status] ||= "Reloading..."
-					
-					send(**message)
-				end
-				
 				private
 				
 				def environment_for(arguments)


### PR DESCRIPTION
These methods are duplicated from `Notify::Client`, which is the parent of `Notify::Pipe`.