### PR TITLE
Avoid Ruby warning on unused variable

### DIFF
--- a/lib/async/container/notify/server.rb
+++ b/lib/async/container/notify/server.rb
@@ -98,7 +98,7 @@ module Async
 					
 					def receive
 						while true
-							data, address, flags, *controls = @bound.recvmsg(MAXIMUM_MESSAGE_SIZE)
+							data, _address, _flags, *_controls = @bound.recvmsg(MAXIMUM_MESSAGE_SIZE)
 							
 							message = Server.load(data)
 							

--- a/spec/async/container/forked_spec.rb
+++ b/spec/async/container/forked_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Async::Container::Forked, if: Async::Container.fork? do
 		
 		3.times do
 			trigger.last.puts "die"
-			child_pid = pids.first.gets
+			_child_pid = pids.first.gets
 		end
 		
 		thread.kill

--- a/spec/async/container/notify/pipe_spec.rb
+++ b/spec/async/container/notify/pipe_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Async::Container::Notify::Pipe do
 		# Wait for the state to be updated by the child process:
 		container.sleep
 		
-		child, state = container.state.first
+		_child, state = container.state.first
 		expect(state).to be == {status: "Initializing..."}
 		
 		container.wait


### PR DESCRIPTION
This PR avoids a few  Ruby warnings which appeared when I ran the  test suite.

Most were in the tests, but one was in a lib/ file.

Example from GitHub Actions:

```
/Users/runner/runners/2.165.2/work/async-container/async-container/spec/async/container/forked_spec.rb:48: warning: assigned but unused variable - child_pid
/Users/runner/runners/2.165.2/work/async-container/async-container/spec/async/container/notify/pipe_spec.rb:41: warning: assigned but unused variable - child
/Users/runner/runners/2.165.2/work/async-container/async-container/lib/async/container/notify/server.rb:101: warning: assigned but unused variable - address
/Users/runner/runners/2.165.2/work/async-container/async-container/lib/async/container/notify/server.rb:101: warning: assigned but unused variable - flags
/Users/runner/runners/2.165.2/work/async-container/async-container/lib/async/container/notify/server.rb:101: warning: assigned but unused variable - controls
```