### PR TITLE
fix: allow Thread#name= to set name

### DIFF
--- a/lib/async/container/thread.rb
+++ b/lib/async/container/thread.rb
@@ -116,7 +116,7 @@ module Async
 			end
 			
 			def name= value
-				@thread.name = name
+				@thread.name = value
 			end
 			
 			def name


### PR DESCRIPTION
This PR fixes an ostensible copypasta error: a setter parameter is named and not used.