### PR TITLE
Examples: implicit return, avoid unused variable

### DIFF
--- a/examples/channel.rb
+++ b/examples/channel.rb
@@ -13,7 +13,7 @@ class Channel
 	
 	def receive
 		if data = @in.gets
-			return JSON.parse(data, symbolize_names: true)
+			JSON.parse(data, symbolize_names: true)
 		end
 	end
 	

--- a/examples/channels/client.rb
+++ b/examples/channels/client.rb
@@ -11,13 +11,14 @@ require 'async/container'
 # 	end
 # 
 # 	def << object
-# 		return :object
+# 		:object
 # 	end
 # 
 # 	def [] key
 # 		return
+# 	end
 # end
-# 
+#
 # class Proxy < BasicObject
 # 	def initialize(bus, name)
 # 		@bus = bus
@@ -62,8 +63,6 @@ require 'async/container'
 # class Channel
 # 	def self.pipe
 # 		input, output = Async::IO.pipe
-# 
-# 
 # 	end
 # 
 # 	def initialize(input, output)

--- a/examples/minimal.rb
+++ b/examples/minimal.rb
@@ -39,7 +39,7 @@ class Threaded
 			@waiter = nil
 		end
 		
-		return @status
+		@status
 	end
 	
 	protected
@@ -86,9 +86,9 @@ class Forked
 	
 	def wait
 		unless @status
-			pid, @status = ::Process.wait(@pid)
+			_pid, @status = ::Process.wait(@pid)
 		end
 		
-		return @status
+		@status
 	end
 end


### PR DESCRIPTION
This PR  updates examples to avoid a -W2 warnings (about an unused variable).

