### PR TITLE
gemspec: Set Ruby req to 2.5+

### DIFF
--- a/async-container.gemspec
+++ b/async-container.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
 	
 	spec.files = Dir.glob('{lib}/**/*', File::FNM_DOTMATCH, base: __dir__)
 
-	spec.required_ruby_version = "~> 2.0"
+	spec.required_ruby_version = "~> 2.5"
 	
 	spec.add_dependency "async", "~> 1.0"
 	spec.add_dependency "async-io", "~> 1.26"


### PR DESCRIPTION
implicit begin-rescue-end are used, so we need it

Fixes #16 