### PR TITLE
Don't override given threads number

### DIFF
--- a/lib/async/container/hybrid.rb
+++ b/lib/async/container/hybrid.rb
@@ -35,7 +35,7 @@ module Async
 				processor_count = Container.processor_count
 				count ||= processor_count ** 2
 				forks ||= [processor_count, count].min
-				threads = (count / forks).ceil
+				threads ||= (count / forks).ceil
 				
 				forks.times do
 					self.spawn(**options) do |instance|


### PR DESCRIPTION
Looks like `threads` option should not be overwritten 

### Types of Changes

- Bug fix.

### Testing

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [X] I tested my changes locally.
