### PR TITLE
Prefer thread current raise

### DIFF
--- a/examples/minimal.rb
+++ b/examples/minimal.rb
@@ -60,8 +60,8 @@ class Forked
 		@status = nil
 		
 		@pid = Process.fork do
-			Signal.trap(:INT) {raise Interrupt}
-			Signal.trap(:INT) {raise Terminate}
+			Signal.trap(:INT) {::Thread.current.raise(Interrupt)}
+			Signal.trap(:INT) {::Thread.current.raise(Terminate)}
 			
 			@channel.in.close
 			

--- a/lib/async/container/controller.rb
+++ b/lib/async/container/controller.rb
@@ -176,16 +176,17 @@ module Async
 			# Enter the controller run loop, trapping `SIGINT` and `SIGTERM`.
 			def run
 				# I thought this was the default... but it doesn't always raise an exception unless you do this explicitly.
+				# We use `Thread.current.raise(...)` so that exceptions are filtered through `Thread.handle_interrupt` correctly.
 				interrupt_action = Signal.trap(:INT) do
-					raise Interrupt
+					::Thread.current.raise(Interrupt)
 				end
 				
 				terminate_action = Signal.trap(:TERM) do
-					raise Terminate
+					::Thread.current.raise(Terminate)
 				end
 				
 				hangup_action = Signal.trap(:HUP) do
-					raise Hangup
+					::Thread.current.raise(Hangup)
 				end
 				
 				self.start

--- a/lib/async/container/generic.rb
+++ b/lib/async/container/generic.rb
@@ -49,6 +49,8 @@ module Async
 				@keyed = {}
 			end
 			
+			attr :group
+			
 			attr :state
 			
 			# A human readable representation of the container.

--- a/lib/async/container/process.rb
+++ b/lib/async/container/process.rb
@@ -66,8 +66,9 @@ module Async
 			def self.fork(**options)
 				self.new(**options) do |process|
 					::Process.fork do
-						Signal.trap(:INT) {raise Interrupt}
-						Signal.trap(:TERM) {raise Terminate}
+						# We use `Thread.current.raise(...)` so that exceptions are filtered through `Thread.handle_interrupt` correctly.
+						Signal.trap(:INT) {::Thread.current.raise(Interrupt)}
+						Signal.trap(:TERM) {::Thread.current.raise(Terminate)}
 						
 						begin
 							yield Instance.for(process)


### PR DESCRIPTION
I'm investigating some odd shutdown behaviour in `async-job` when integrated with Rails. An exception is being raised during `Thread.handle_interrupt` incorrectly. Using `Thread.current.raise` prevents this.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
