### PR TITLE
Ensure the container is stopped if it's not correctly started.

### DIFF
--- a/lib/async/container/controller.rb
+++ b/lib/async/container/controller.rb
@@ -135,18 +135,20 @@ module Async
 					raise SetupError, container
 				end
 				
-				# Make this swap as atomic as possible:
+				# The following swap should be atomic:
 				old_container = @container
 				@container = container
+				container = nil
 				
-				Console.logger.debug(self, "Stopping old container...")
-				old_container&.stop
+				if old_container
+					Console.logger.debug(self, "Stopping old container...")
+					old_container&.stop
+				end
+				
 				@notify&.ready!
-			rescue
+			ensure
 				# If we are leaving this function with an exception, try to kill the container:
 				container&.stop(false)
-				
-				raise
 			end
 			
 			# Reload the existing container. Children instances will be reloaded using `SIGHUP`.


### PR DESCRIPTION
`rescue => error` is not the same as `ensure`. Fix this code.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [ ] I tested my changes locally.
- [ ] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
