### PR TITLE
Use `SIGKILL`/`Thread#kill` when the health check fails.

### DIFF
--- a/fixtures/async/container/a_container.rb
+++ b/fixtures/async/container/a_container.rb
@@ -201,7 +201,23 @@ module Async
 						instance.ready!
 						
 						# This should trigger the health check - since restart is false, the process will be terminated:
-						sleep(2.0)
+						sleep
+					end
+					
+					container.wait
+					
+					expect(container.statistics).to have_attributes(failures: be > 0)
+				end
+				
+				it "can kill a child process even if it ignores exceptions/signals" do
+					container.spawn(health_check_timeout: 1.0) do |instance|
+						while true
+							begin
+								sleep 1
+							rescue Exception => error
+								# Ignore.
+							end
+						end
 					end
 					
 					container.wait

--- a/lib/async/container/forked.rb
+++ b/lib/async/container/forked.rb
@@ -180,6 +180,13 @@ module Async
 					end
 				end
 				
+				# Send `SIGKILL` to the child process.
+				def kill!
+					unless @status
+						::Process.kill(:KILL, @pid)
+					end
+				end
+				
 				# Send `SIGHUP` to the child process.
 				def restart!
 					unless @status

--- a/lib/async/container/generic.rb
+++ b/lib/async/container/generic.rb
@@ -172,8 +172,8 @@ module Async
 								when :health_check!
 									if health_check_timeout&.<(age_clock.total)
 										Console.warn(self, "Child failed health check!", child: child, age: age_clock.total, health_check_timeout: health_check_timeout)
-										# If the child has failed the health check, we assume the worst and terminate it (SIGTERM).
-										child.terminate!
+										# If the child has failed the health check, we assume the worst and kill it immediately:
+										child.kill!
 									end
 								else
 									state.update(message)

--- a/releases.md
+++ b/releases.md
@@ -1,5 +1,9 @@
 # Releases
 
+## Unreleased
+
+  - Use `SIGKILL`/`Thread#kill` when the health check fails. In some cases, `SIGTERM` may not be sufficient to terminate a process because the signal can be ignored or the process may be in an uninterruptible state.
+
 ## v0.20.1
 
   - Fix compatibility between {ruby Async::Container::Hybrid} and the health check.

--- a/test/async/container/controller.rb
+++ b/test/async/container/controller.rb
@@ -25,18 +25,16 @@ describe Async::Container::Controller do
 				container.spawn(key: "test") do |instance|
 					instance.ready!
 					
-					sleep(0.2)
-					
 					@output.write(".")
 					@output.flush
 					
-					sleep(0.4)
+					sleep(0.2)
 				end
 				
 				container.spawn do |instance|
 					instance.ready!
 					
-					sleep(0.3)
+					sleep(0.1)
 					
 					@output.write(",")
 					@output.flush
@@ -52,6 +50,7 @@ describe Async::Container::Controller do
 			controller.reload
 			
 			expect(input.read(1)).to be == ","
+			
 			controller.wait
 		end
 	end


### PR DESCRIPTION
While creating the `giber-profiler`, I managed to create some badly behaving C code, which caused the process to hang AND fail to handle SIGTERM. In the case of a health check failure, we should assume the worst.

Perhaps later we can implement a SIGTERM -> SIGKILL after a timeout, but for now I'd rather err on the side of caution and kill the child worker if it is unresponsive.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.
- New feature.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
