### PR TITLE
Log-Based Readiness Notification for Kubernetes Probes in `async-container`

### DIFF
--- a/lib/async/container/notify.rb
+++ b/lib/async/container/notify.rb
@@ -6,6 +6,7 @@
 require_relative "notify/pipe"
 require_relative "notify/socket"
 require_relative "notify/console"
+require_relative "notify/log"
 
 module Async
 	module Container
@@ -18,6 +19,7 @@ module Async
 				@client ||= (
 					Pipe.open! ||
 					Socket.open! ||
+					Log.open! ||
 					Console.open!
 				)
 			end

--- a/lib/async/container/notify/log.rb
+++ b/lib/async/container/notify/log.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2020-2024, by Samuel Williams.
+
+require_relative "client"
+require "socket"
+
+module Async
+	module Container
+		module Notify
+			class Log < Client
+				# The name of the environment variable which contains the path to the notification socket.
+				NOTIFY_LOG = "NOTIFY_LOG"
+				
+				# Open a notification client attached to the current {NOTIFY_LOG} if possible.
+				def self.open!(environment = ENV)
+					if path = environment.delete(NOTIFY_LOG)
+						self.new(path)
+					end
+				end
+				
+				# Initialize the notification client.
+				# @parameter path [String] The path to the UNIX socket used for sending messages to the process manager.
+				def initialize(path)
+					@path = path
+				end
+				
+				# @attribute [String] The path to the UNIX socket used for sending messages to the controller.
+				attr :path
+				
+				# Send the given message.
+				# @parameter message [Hash]
+				def send(**message)
+					data = JSON.dump(message)
+					
+					File.open(@path, "a") do |file|
+						file.puts(data)
+					end
+				end
+				
+				# Send the specified error.
+				# `sd_notify` requires an `errno` key, which defaults to `-1` to indicate a generic error.
+				def error!(text, **message)
+					message[:errno] ||= -1
+					
+					super
+				end
+			end
+		end
+	end
+end

--- a/lib/async/container/notify/server.rb
+++ b/lib/async/container/notify/server.rb
@@ -5,6 +5,7 @@
 # Copyright, 2020, by Olle Jonsson.
 
 require "tmpdir"
+require "socket"
 require "securerandom"
 
 module Async

--- a/test/async/container/notify/log.rb
+++ b/test/async/container/notify/log.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2020-2025, by Samuel Williams.
+# Copyright, 2020, by Olle Jonsson.
+
+require "async/container/controller"
+require "async/container/controllers"
+
+require "tmpdir"
+
+describe Async::Container::Notify::Pipe do
+	let(:notify_script) {Async::Container::Controllers.path_for("notify")}
+	let(:notify_log) {File.expand_path("notify-#{::Process.pid}-#{SecureRandom.hex(8)}.log", Dir.tmpdir)}
+	
+	it "receives notification of child status" do
+		system({"NOTIFY_LOG" => notify_log}, "bundle", "exec", notify_script)
+		
+		lines = File.readlines(notify_log).map{|line| JSON.parse(line)}
+		
+		expect(lines.last).to be == {"ready" => true}
+	end
+end


### PR DESCRIPTION
Kubernetes has an out-of-band readiness probe, which does not follow the `sd_notify` model. To integrate `async-container` controllers with Kubernetes, readiness notifications can now be written to a log file, which Kubernetes can check using a readiness probe.

## Usage

To enable this feature, set the `NOTIFY_LOG` environment variable when running a containerized application:

```sh
NOTIFY_LOG=/tmp/notify.log falcon host
```

During startup, the process logs structured JSON messages:

```
{"status":"Initializing..."}
{"ready":true}
```

Once the log contains `{"ready":true}`, Kubernetes can detect that the process is ready.

## Example: Kubernetes Deployment Configuration

The following Kubernetes deployment defines an **exec-based readiness probe** to check for the readiness message in the log file:

```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: falcon
spec:
  replicas: 1
  selector:
    matchLabels:
      app: falcon
  template:
    metadata:
      labels:
        app: falcon
    spec:
      containers:
        - name: falcon
          image: your-container-image
          env:
            - name: NOTIFY_LOG
              value: "/tmp/notify.log"
          command: ["falcon", "host"]
          readinessProbe:
            exec:
              command: ["sh", "-c", "grep -q '\"ready\":true' /tmp/notify.log"]
            initialDelaySeconds: 5
            periodSeconds: 5
            failureThreshold: 3
```

---

### **How It Works**
1. The process writes readiness messages to `/tmp/notify.log`.
2. Kubernetes executes `grep -q '\"ready\":true' /tmp/notify.log` every 5 seconds.
3. If the message is found, the pod is marked **Ready**.
4. If the message is missing, the pod remains in **Not Ready** state.
5. If the probe fails three times, Kubernetes considers the pod unhealthy.

This allows `async-container` controllers to integrate with Kubernetes readiness probes without requiring systemd or additional dependencies.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- New feature.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
