### PR TITLE
Initial metrics for health check failure.

### DIFF
--- a/config/metrics.rb
+++ b/config/metrics.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2025, by Samuel Williams.
+
+def prepare
+	require "metrics/provider/async/container"
+end

--- a/config/sus.rb
+++ b/config/sus.rb
@@ -7,3 +7,14 @@ require "covered/sus"
 include Covered::Sus
 
 ENV["CONSOLE_LEVEL"] ||= "fatal"
+ENV["METRICS_BACKEND"] ||= "metrics/backend/test"
+
+def prepare_instrumentation!
+	require "metrics"
+end
+
+def before_tests(...)
+	prepare_instrumentation!
+	
+	super
+end

--- a/examples/health_check/test.rb
+++ b/examples/health_check/test.rb
@@ -5,7 +5,8 @@
 # Copyright, 2022, by Anton Sozontov.
 # Copyright, 2024, by Samuel Williams.
 
-require "../../lib/async/container/controller"
+require "metrics"
+require_relative "../../lib/async/container/controller"
 
 NAMES = [
 	"Cupcake", "Donut", "Eclair", "Froyo", "Gingerbread", "Honeycomb", "Ice Cream Sandwich", "Jelly Bean", "KitKat", "Lollipop", "Marshmallow", "Nougat", "Oreo", "Pie", "Apple Tart"

--- a/gems.rb
+++ b/gems.rb
@@ -21,6 +21,8 @@ group :test do
 	gem "decode"
 	gem "rubocop"
 	
+	gem "metrics"
+	
 	gem "bake-test"
 	gem "bake-test-external"
 end

--- a/lib/metrics/provider/async/container.rb
+++ b/lib/metrics/provider/async/container.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2025, by Samuel Williams.
+
+require_relative "container/generic"

--- a/lib/metrics/provider/async/container/generic.rb
+++ b/lib/metrics/provider/async/container/generic.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2025, by Samuel Williams.
+
+require_relative "../../../../async/container/generic"
+require "metrics/provider"
+
+Metrics::Provider(Async::Container::Generic) do
+	ASYNC_CONTAINER_GENERIC_HEALTH_CHECK_FAILED = Metrics.metric("async.container.generic.health_check_failed", :counter, description: "The number of health checks that failed.")
+	
+	protected def health_check_failed!(child, age_clock, health_check_timeout)
+		ASYNC_CONTAINER_GENERIC_HEALTH_CHECK_FAILED.emit(1)
+		
+		super
+	end
+end


### PR DESCRIPTION
Initial support for emitting `async.container.generic.health_check_failed` metric.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- New feature.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
