### PR TITLE
Better Kubernetes readiness check.

### DIFF
--- a/bake/async/container/notify/log.rb
+++ b/bake/async/container/notify/log.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 
 def initialize(...)
 	super

--- a/bake/async/container/notify/log.rb
+++ b/bake/async/container/notify/log.rb
@@ -1,0 +1,23 @@
+
+def initialize(...)
+	super
+	
+	require "async/container/notify/log"
+end
+
+# Check if the log file exists and the service is ready.
+def ready?(path: Async::Container::Notify::Log.path)
+	if File.exist?(path)
+		File.foreach(path) do |line|
+			message = JSON.parse(line)
+			if message["ready"] == true
+				$stderr.puts "Service is ready: #{line}"
+				return true
+			end
+		end
+		
+		raise "Service is not ready yet."
+	else
+		raise "Notification log file does not exist at #{path}"
+	end
+end

--- a/bake/async/container/notify/log.rb
+++ b/bake/async/container/notify/log.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+# Released under the MIT License.
+# Copyright, 2025, by Samuel Williams.
+
 def initialize(...)
 	super
 	

--- a/bake/async/container/notify/log.rb
+++ b/bake/async/container/notify/log.rb
@@ -6,6 +6,7 @@ def initialize(...)
 end
 
 # Check if the log file exists and the service is ready.
+# @parameter path [String] The path to the notification log file, uses the `NOTIFY_LOG` environment variable if not provided.
 def ready?(path: Async::Container::Notify::Log.path)
 	if File.exist?(path)
 		File.foreach(path) do |line|

--- a/guides/getting-started/readme.md
+++ b/guides/getting-started/readme.md
@@ -85,25 +85,3 @@ controller.run
 `SIGKILL` is the kill signal. The only behavior is to kill the process, immediately. As the process cannot catch the signal, it cannot cleanup, and thus this is a signal of last resort.
 
 `SIGSTOP` is the pause signal. The only behavior is to pause the process; the signal cannot be caught or ignored. The shell uses pausing (and its counterpart, resuming via `SIGCONT`) to implement job control.
-
-## Integration
-
-### systemd
-
-Install a template file into `/etc/systemd/system/`:
-
-```
-# my-daemon.service
-[Unit]
-Description=My Daemon
-AssertPathExists=/srv/
-
-[Service]
-Type=notify
-WorkingDirectory=/srv/my-daemon
-ExecStart=bundle exec my-daemon
-Nice=5
-
-[Install]
-WantedBy=multi-user.target
-```

--- a/guides/kubernetes-integration/readme.md
+++ b/guides/kubernetes-integration/readme.md
@@ -1,0 +1,39 @@
+# Kubernetes Integration
+
+This guide explains how to use `async-container` with Kubernetes to manage your application as a containerized service.
+
+## Deployment Configuration
+
+Create a deployment configuration file for your application:
+
+```yaml
+# my-app-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: my-app
+  template:
+    metadata:
+      labels:
+        app: my-app
+    spec:
+      containers:
+        - name: my-app
+          image: my-app-image:latest
+          env:
+            - name: NOTIFY_LOG
+              value: "/tmp/notify.log"
+          ports:
+            - containerPort: 3000
+          readinessProbe:
+            exec:
+              command: ["bundle", "exec", "bake", "async:container:notify:log:ready?"]
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            failureThreshold: 12
+```

--- a/guides/links.yaml
+++ b/guides/links.yaml
@@ -1,0 +1,8 @@
+getting-started:
+  order: 1
+systemd-integration:
+  order: 2
+kubernetes-integration:
+  order: 3
+docker-integration:
+  order: 4

--- a/guides/systemd-integration/readme.md
+++ b/guides/systemd-integration/readme.md
@@ -1,0 +1,22 @@
+# Systemd Integration
+
+This guide explains how to use `async-container` with systemd to manage your application as a service.
+
+## Service File
+
+Install a template file into `/etc/systemd/system/`:
+
+```
+# my-daemon.service
+[Unit]
+Description=My Daemon
+
+[Service]
+Type=notify
+ExecStart=bundle exec my-daemon
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Ensure `Type=notify` is set, so that the service can notify systemd when it is ready.

--- a/lib/async/container/forked.rb
+++ b/lib/async/container/forked.rb
@@ -189,6 +189,7 @@ module Async
 					"\#<#{self.class} name=#{@name.inspect} status=#{@status.inspect} pid=#{@pid.inspect}>"
 				end
 				
+				# @returns [String] A string representation of the process.
 				alias to_s inspect
 				
 				# Invoke {#terminate!} and then {#wait} for the child process to exit.

--- a/lib/async/container/notify/log.rb
+++ b/lib/async/container/notify/log.rb
@@ -14,9 +14,13 @@ module Async
 				# The name of the environment variable which contains the path to the notification socket.
 				NOTIFY_LOG = "NOTIFY_LOG"
 				
+				def self.path(environment = ENV)
+					environment[NOTIFY_LOG]
+				end
+
 				# Open a notification client attached to the current {NOTIFY_LOG} if possible.
 				def self.open!(environment = ENV)
-					if path = environment.delete(NOTIFY_LOG)
+					if path = self.path(environment)
 						self.new(path)
 					end
 				end

--- a/lib/async/container/notify/log.rb
+++ b/lib/async/container/notify/log.rb
@@ -19,7 +19,7 @@ module Async
 				def self.path(environment = ENV)
 					environment[NOTIFY_LOG]
 				end
-
+				
 				# Open a notification client attached to the current {NOTIFY_LOG} if possible.
 				# @parameter environment [Hash] The environment variables, defaults to `ENV`.
 				def self.open!(environment = ENV)

--- a/lib/async/container/notify/log.rb
+++ b/lib/async/container/notify/log.rb
@@ -14,11 +14,14 @@ module Async
 				# The name of the environment variable which contains the path to the notification socket.
 				NOTIFY_LOG = "NOTIFY_LOG"
 				
+				# @returns [String] The path to the notification log file.
+				# @parameter environment [Hash] The environment variables, defaults to `ENV`.
 				def self.path(environment = ENV)
 					environment[NOTIFY_LOG]
 				end
 
 				# Open a notification client attached to the current {NOTIFY_LOG} if possible.
+				# @parameter environment [Hash] The environment variables, defaults to `ENV`.
 				def self.open!(environment = ENV)
 					if path = self.path(environment)
 						self.new(path)

--- a/lib/async/container/notify/pipe.rb
+++ b/lib/async/container/notify/pipe.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Released under the MIT License.
-# Copyright, 2020-2024, by Samuel Williams.
+# Copyright, 2020-2025, by Samuel Williams.
 # Copyright, 2020, by Juan Antonio Martín Lucas.
 
 require_relative "client"

--- a/releases.md
+++ b/releases.md
@@ -1,5 +1,9 @@
 # Releases
 
+## Unreleased
+
+  - Introduce `async:container:notify:log:ready?` task for detecting process readiness.
+
 ## v0.24.0
 
   - Add support for health check failure metrics.

--- a/test/async/container/hybrid.rb
+++ b/test/async/container/hybrid.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Released under the MIT License.
-# Copyright, 2019-2024, by Samuel Williams.
+# Copyright, 2019-2025, by Samuel Williams.
 
 require "async/container/hybrid"
 require "async/container/best"

--- a/test/async/container/notify/log.rb
+++ b/test/async/container/notify/log.rb
@@ -7,11 +7,17 @@ require "async/container/controller"
 require "async/container/controllers"
 
 require "tmpdir"
+require "bake"
 
-describe Async::Container::Notify::Pipe do
+describe Async::Container::Notify::Log do
 	let(:notify_script) {Async::Container::Controllers.path_for("notify")}
 	let(:notify_log) {File.expand_path("notify-#{::Process.pid}-#{SecureRandom.hex(8)}.log", Dir.tmpdir)}
+	let(:notify) {Async::Container::Notify::Log.open!({"NOTIFY_LOG" => notify_log})}
 	
+	after do
+		File.unlink(notify_log) rescue nil
+	end
+
 	it "receives notification of child status" do
 		system({"NOTIFY_LOG" => notify_log}, "bundle", "exec", notify_script)
 		
@@ -21,5 +27,30 @@ describe Async::Container::Notify::Pipe do
 			"ready" => be == true,
 			"size" => be > 0,
 		)
+	end
+
+	with "async:container:notify:log:ready?" do
+		let(:context) {Bake::Context.load}
+		let(:recipe) {context.lookup("async:container:notify:log:ready?")}
+
+		it "fails if the log file does not exist" do
+			expect do
+				recipe.call(path: "nonexistant.log")
+			end.to raise_exception(RuntimeError, message: be =~ /log file does not exist/i)
+		end
+
+		it "succeeds if the log file exists and is ready" do
+			notify.ready!
+
+			expect(recipe.call(path: notify_log)).to be == true
+		end
+
+		it "fails if the log file exists but is not ready" do
+			notify.status!("Loading...")
+			
+			expect do
+				expect(recipe.call(path: notify_log))
+			end.to raise_exception(RuntimeError, message: be =~ /service is not ready/i)
+		end
 	end
 end

--- a/test/async/container/notify/log.rb
+++ b/test/async/container/notify/log.rb
@@ -17,7 +17,7 @@ describe Async::Container::Notify::Log do
 	after do
 		File.unlink(notify_log) rescue nil
 	end
-
+	
 	it "receives notification of child status" do
 		system({"NOTIFY_LOG" => notify_log}, "bundle", "exec", notify_script)
 		
@@ -28,23 +28,23 @@ describe Async::Container::Notify::Log do
 			"size" => be > 0,
 		)
 	end
-
+	
 	with "async:container:notify:log:ready?" do
 		let(:context) {Bake::Context.load}
 		let(:recipe) {context.lookup("async:container:notify:log:ready?")}
-
+		
 		it "fails if the log file does not exist" do
 			expect do
 				recipe.call(path: "nonexistant.log")
 			end.to raise_exception(RuntimeError, message: be =~ /log file does not exist/i)
 		end
-
+		
 		it "succeeds if the log file exists and is ready" do
 			notify.ready!
-
+			
 			expect(recipe.call(path: notify_log)).to be == true
 		end
-
+		
 		it "fails if the log file exists but is not ready" do
 			notify.status!("Loading...")
 			


### PR DESCRIPTION
Introduce `bake async:container:notify:log:ready?` check for better Kubernetes integration.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- New feature.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
