### PR TITLE
Move error handling to ensure loop continues after child process management

### DIFF
--- a/lib/async/container/generic.rb
+++ b/lib/async/container/generic.rb
@@ -203,11 +203,13 @@ module Async
 									age_clock&.reset!
 								end
 							end
+						rescue => error
+							Console.error(self, "Error during child process management!", exception: error, running: @running)
 						ensure
 							delete(key, child)
 						end
 						
-						if status.success?
+						if status&.success?
 							Console.info(self, "Child exited successfully.", status: status, running: @running)
 						else
 							@statistics.failure!
@@ -220,9 +222,6 @@ module Async
 							break
 						end
 					end
-				rescue => error
-					Console.error(self, "Failure during child process management!", exception: error, running: @running)
-					raise
 				ensure
 					Console.info(self, "Child process management loop exited.", running: @running)
 				end.resume


### PR DESCRIPTION
If a process dies right before we call `kill!` here: https://github.com/socketry/async-container/blob/2826b6edb14036e8164b41bfbe2d96a012806ba6/lib/async/container/forked.rb#L249, the resulting `::Process.kill(:KILL, @pid)` will throw an error (`Errno::ESRCH (No such process)`), and the run loop will exit.

We do want to keep the loop running.

So this PR removes the re-raise, and move the `rescue` higher up so we count it as a failure.