### PR TITLE
Use a process group for isolation.

### DIFF
--- a/releases.md
+++ b/releases.md
@@ -1,5 +1,9 @@
 # Releases
 
+## Unreleased
+
+  - Use a process group for forked children, so that signals sent from the terminal are isolated to the foreground process.
+
 ## v0.30.0
 
   - `SIGTERM` is now graceful, the same as `SIGINT`, for better compatibility with Kubernetes and systemd.


### PR DESCRIPTION
When pressing Ctrl-C on the terminal, the entire foreground process group is signalled. Since the controller will also send SIGINT, this causes a double up of signals, breaking graceful exit (e.g. `defer_stop`).

In addition when sending SIGKILL, the entire process group is killed, preventing processes from being leaked.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
