### PR TITLE
Drop per-fork shutdown deadline in `Hybrid#run`

### DIFF
--- a/lib/async/container/hybrid.rb
+++ b/lib/async/container/hybrid.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Released under the MIT License.
-# Copyright, 2019-2025, by Samuel Williams.
+# Copyright, 2019-2026, by Samuel Williams.
 # Copyright, 2022, by Anton Sozontov.
 
 require_relative "forked"
@@ -37,8 +37,15 @@ module Async
 						container.stop(false)
 						raise
 					ensure
-						# Stop it gracefully (also code path for Interrupt):
-						container.stop
+						# Graceful drain on Interrupt. The inner per-fork container imposes
+						# no wall-clock deadline of its own — the parent's `Group#stop(graceful)`
+						# is the authoritative timer, via `Forked::Child.wait(timeout)` followed
+						# by `kill!` escalation if the fork doesn't exit within budget. A finite
+						# value here would race the parent's budget (most visibly when they're
+						# equal, e.g. configured at 30s on both layers); `Float::INFINITY` lets
+						# the inner threads exit at their own pace so the parent's escalation
+						# remains the single source of shutdown timing.
+						container.stop(Float::INFINITY)
 					end
 				end
 				

--- a/test/async/container/hybrid.rb
+++ b/test/async/container/hybrid.rb
@@ -14,3 +14,62 @@ describe Async::Container::Hybrid do
 		expect(subject).to be(:multiprocess?)
 	end
 end if Async::Container.fork?
+
+describe Async::Container::Hybrid do
+	# Pin the inner per-fork ensure-block contract without actually forking: override
+	# `#spawn` so the block runs in-process and stub `Threaded.new` so the inner
+	# `#stop` call can be observed. The parent `Group#stop(graceful)` is the
+	# authoritative deadline for fork exit (`Forked::Child.wait(timeout)` then
+	# `kill!`); the inner per-fork shutdown must therefore impose no deadline of
+	# its own, otherwise the two budgets race when configured equally.
+	with "inner per-fork shutdown timing" do
+		let(:inner_stop_calls) {[]}
+		
+		let(:threaded_double) do
+			double = Object.new
+			stops = inner_stop_calls
+			double.define_singleton_method(:run){|**|}
+			double.define_singleton_method(:wait_until_ready){}
+			double.define_singleton_method(:wait){raise Interrupt}
+			double.define_singleton_method(:stop){|arg = :__no_arg__| stops << arg}
+			double
+		end
+		
+		let(:fake_instance) do
+			instance = Object.new
+			instance.define_singleton_method(:ready!){}
+			instance
+		end
+		
+		def run_hybrid_inline(hybrid, instance:)
+			hybrid.define_singleton_method(:spawn) do |**options, &block|
+				begin
+					block.call(instance)
+				rescue Interrupt
+					# Swallow: simulates the forked process exiting on Interrupt.
+				end
+			end
+			hybrid.run(forks: 1, threads: 1, count: 1){}
+		end
+		
+		def with_threaded_stubbed(double)
+			original = Async::Container::Threaded.method(:new)
+			Async::Container::Threaded.singleton_class.send(:define_method, :new){|*, **, &| double}
+			begin
+				yield
+			ensure
+				Async::Container::Threaded.singleton_class.send(:remove_method, :new)
+				Async::Container::Threaded.singleton_class.send(:define_method, :new, original)
+			end
+		end
+		
+		it "drains the inner Threaded container without imposing its own deadline" do
+			with_threaded_stubbed(threaded_double) do
+				hybrid = Async::Container::Hybrid.new
+				run_hybrid_inline(hybrid, instance: fake_instance)
+			end
+			
+			expect(inner_stop_calls).to be == [Float::INFINITY]
+		end
+	end
+end if Async::Container.fork?


### PR DESCRIPTION
## Summary

`Async::Container::Hybrid#run`'s ensure block called `container.stop` on the inner per-fork `Threaded` sub-container with no positional argument. `Generic#stop(timeout = true)` forwarded the literal `true` to `Group#stop`, which expanded it to `DEFAULT_GRACEFUL_TIMEOUT = 10.0`. The effect: every Hybrid deployment capped its per-request drain budget at 10 seconds, regardless of what `Container::Controller#@graceful_stop` was configured to. A configured `graceful_stop: 30` produced an effective 10s drain.

This PR removes the inner per-fork deadline entirely. The parent `Container::Controller#stop(graceful)` already imposes the authoritative wall-clock deadline on fork exit, via `Group#stop(graceful)` → `Forked::Child.wait(timeout)` → `kill!` escalation if the fork doesn't exit within budget. The inner ensure block now drains permissively (`Float::INFINITY`) and lets the parent's escalation drive termination.

## Change

```ruby
ensure
- container.stop
+ container.stop(Float::INFINITY)
```

That's the entire behavioral change. No new public API, no new kwargs, no state added to `Generic` or `Hybrid`, no change to `Controller#create_container`. `Container::Controller#@graceful_stop` remains the single source of truth for shutdown timing.

## Why `Float::INFINITY`, not `true` or a finite value

- `true` (the prior behavior) → expands to the hardcoded 10s default in `Group#stop`. The bug.
- A finite value (e.g. 30s, or anything that tries to mirror the outer budget) races the parent's `Forked::Child.wait(timeout)` when the two are equal. The natural configuration (one `graceful_stop:` value applied at both layers) is exactly when the race triggers, so a finite inner deadline codifies the race rather than fixing it.
- `false` → force-kill, which skips the graceful drain that the ensure path exists to provide.
- `Float::INFINITY` → no per-fork deadline; the inner threads exit at their own pace; the parent's `kill!` escalation is the only wall-clock bound. The race is structurally impossible because the inner has no budget to race against.

## End-to-end behavior

`Async::Service::Controller.run(graceful_stop: 30)` (with the companion socketry/async-service#8 also applied) →
`@graceful_stop = 30` on the outer Controller →
SIGTERM → `Container::Controller#run` rescues Interrupt → `self.stop` → `@container.stop(30)` → `Generic#stop(30)` → `Group#stop(30)` →
for each fork: `Forked::Child.wait(30)` blocks up to 30s; if the child hasn't exited, `kill!` (SIGKILL).

Inside each forked process (independent of any outer configuration):
SIGTERM/SIGINT propagates → `container.wait` raises Interrupt → ensure fires → `container.stop(Float::INFINITY)` → inner `@group.stop(Float::INFINITY)` → threads drain at their own pace. The parent's 30s budget bounds them.

The 30s budget is enforced exactly once, by the parent. No race. No duplicated state.

## Tests

New unit test in `test/async/container/hybrid.rb` pins the ensure-block contract without actually forking:

```ruby
it "drains the inner Threaded container without imposing its own deadline" do
  with_threaded_stubbed(threaded_double) do
    hybrid = Async::Container::Hybrid.new
    run_hybrid_inline(hybrid, instance: fake_instance)
  end

  expect(inner_stop_calls).to be == [Float::INFINITY]
end
```

It overrides `#spawn` on the test instance so the run block executes in-process, stubs `Threaded.new` to capture the ensure-block `#stop` argument, and asserts `[Float::INFINITY]`. The existing `it_behaves_like Async::Container::AContainer` shared spec continues to exercise the real fork + SIGINT + drain path end-to-end.

## Backward compatibility

- No public API change. `Hybrid#initialize`, `Hybrid#run`, `Generic#initialize`, `Generic#stop`, `Container::Controller#create_container`, and `Container::Controller#stop` all retain their existing signatures and behavior.
- Any direct caller of `Hybrid#run` continues to work unchanged.
- The only behavioral change is that bare `container.stop` inside the spawn block's ensure clause is replaced by `container.stop(Float::INFINITY)`. No code path outside `Hybrid#run` exercises that internal call.

## Coordination

Companion PR on `async-service`: socketry/async-service#8 — restores the outer `Service::Controller#stop(graceful = @graceful_stop)` default that was being shadowed by a subclass override. Independent; either lands cleanly on its own. A Falcon-on-Hybrid deployment honors a configured `graceful_stop` end-to-end only with both fixes in place.

## Test plan

- [x] New test fails on unmodified `main` and passes with the change.
- [x] Full async-container test suite passes: 168/168.
- [x] `bundle exec rubocop` clean.

cc @ioquatix