### PR TITLE
Fix Hybrid fork respawn loop on single interrupt (#58)

### DIFF
--- a/lib/async/container/generic.rb
+++ b/lib/async/container/generic.rb
@@ -117,6 +117,10 @@ module Async
 			
 			# Gracefully interrupt all child instances.
 			def interrupt
+				# We must enter the stopping state before signalling the children. Interrupting a child causes it to drain and exit, but the main run loop will respawn any child that exits while `restart: true` and the container is not stopping (see the `restart && !@stopping` gate in `#run`). Without setting this flag, an interrupted child immediately respawns, so the container never drains and `#wait` never returns.
+				#
+				# This matters most for `Hybrid` containers: a `SIGINT`/`SIGTERM` delivered to a fork is translated into a call to `#interrupt` on the inner threaded container, which typically runs with `restart: true` (the default for `async-service` managed services). If `#interrupt` did not set this flag, the inner threads would drain, exit, and respawn in a loop, so a single signal would never terminate the fork. Setting `@stopping = true` here makes `#interrupt` behave as the start of a graceful shutdown: children drain and exit, are not respawned, and the fork terminates - consistent with how `Forked` and `Threaded` containers handle a single interrupt.
+				@stopping = true
 				@group.interrupt
 			end
 			

--- a/test/async/container/hybrid.rb
+++ b/test/async/container/hybrid.rb
@@ -61,4 +61,43 @@ describe Async::Container::Hybrid do
 		Async::Container.send(:remove_const, :Threaded)
 		Async::Container.const_set(:Threaded, original_threaded)
 	end
+	
+	# https://github.com/socketry/async-container/issues/58
+	it "exits the fork on a single interrupt even when the inner container has restart: true" do
+		pids = IO.pipe
+		
+		container = subject.new
+		container.run(count: 1, forks: 1, threads: 1, restart: true) do |instance|
+			pids.last.puts(Process.pid.to_s)
+			instance.ready!
+			sleep
+		end
+		
+		container.wait_until_ready
+		
+		fork_pid = Integer(pids.first.gets)
+		
+		# Mimic a single SIGINT delivered to the fork (e.g. memory-based worker recycling):
+		Process.kill(:INT, fork_pid)
+		
+		# The fork must drain its inner threads and exit, rather than respawning them forever:
+		exited = false
+		8.times do
+			reaped, _status = Process.waitpid2(fork_pid, Process::WNOHANG)
+			if reaped
+				exited = true
+				break
+			end
+			sleep(0.1)
+		rescue Errno::ECHILD
+			exited = true
+			break
+		end
+		
+		expect(exited).to be == true
+	ensure
+		Process.kill(:KILL, fork_pid) if fork_pid && !exited
+		container&.stop
+		pids&.each(&:close)
+	end
 end if Async::Container.fork?


### PR DESCRIPTION
## Summary

Fixes #58.

A single `SIGINT`/`SIGTERM` delivered to a `Hybrid` fork no longer drained and exited when the inner threaded container ran with `restart: true` (the default for `async-service` managed services). The inner threads would drain, exit, and immediately respawn, so the fork looped forever and never exited.

This regressed behaviour that held through v0.34.x and broke single-signal worker recycling (e.g. `async-container-supervisor`'s `MemoryMonitor`, which sends one `Process.kill(:INT, pid)`).

## Root cause

`Hybrid#run`'s interrupt path calls `container.interrupt` on the inner threaded container, but `Generic#interrupt` never set `@stopping`. The run loop's respawn gate is:

```ruby
if restart && !@stopping
  @statistics.restart!
else
  break
end
```

With `@stopping` still `false`, interrupted children respawned instead of staying down, so the group never emptied and `#wait` never returned.

## Fix

`Generic#interrupt` now sets `@stopping = true` before signalling children. This makes `#interrupt` behave as the start of a graceful shutdown: children drain and exit, are not respawned, and the fork terminates — consistent with how `Forked` and `Threaded` containers handle a single interrupt.

## Testing

- Adds a regression test (`test/async/container/hybrid.rb`) based on the standalone repro from #58: a `Hybrid` container with `forks: 1, threads: 1, restart: true` must exit its fork after a single `SIGINT`.
- Full suite passes (169/169).
