### PR TITLE
Add SIGTERM regression test for Hybrid fork interrupt handling

### DIFF
--- a/test/async/container/hybrid.rb
+++ b/test/async/container/hybrid.rb
@@ -63,10 +63,14 @@ describe Async::Container::Hybrid do
 	end
 	
 	# https://github.com/socketry/async-container/issues/58
-	it "exits the fork on a single interrupt even when the inner container has restart: true" do
+	#
+	# SIGINT and SIGTERM are intentionally equivalent: both are trapped in the fork and converted into `Interrupt` (see `Forked::Child.fork`), so a single signal of either kind must drain the inner threads and exit, rather than respawning them forever (the inner container has `restart: true`, the default for `async-service` managed services).
+	def exits_fork_on_single_signal(signal)
 		pids = IO.pipe
-		
+		fork_pid = nil
+		exited = false
 		container = subject.new
+		
 		container.run(count: 1, forks: 1, threads: 1, restart: true) do |instance|
 			pids.last.puts(Process.pid.to_s)
 			instance.ready!
@@ -77,11 +81,10 @@ describe Async::Container::Hybrid do
 		
 		fork_pid = Integer(pids.first.gets)
 		
-		# Mimic a single SIGINT delivered to the fork (e.g. memory-based worker recycling):
-		Process.kill(:INT, fork_pid)
+		# Mimic a single signal delivered to the fork (e.g. memory-based worker recycling):
+		Process.kill(signal, fork_pid)
 		
 		# The fork must drain its inner threads and exit, rather than respawning them forever:
-		exited = false
 		8.times do
 			reaped, _status = Process.waitpid2(fork_pid, Process::WNOHANG)
 			if reaped
@@ -99,5 +102,13 @@ describe Async::Container::Hybrid do
 		Process.kill(:KILL, fork_pid) if fork_pid && !exited
 		container&.stop
 		pids&.each(&:close)
+	end
+	
+	it "exits the fork on a single SIGINT even when the inner container has restart: true" do
+		exits_fork_on_single_signal(:INT)
+	end
+	
+	it "exits the fork on a single SIGTERM even when the inner container has restart: true" do
+		exits_fork_on_single_signal(:TERM)
 	end
 end if Async::Container.fork?


### PR DESCRIPTION
## Summary

Follow-up to #58 / #59.

`SIGINT` and `SIGTERM` are intentionally treated as equivalent in this library: both are trapped in each fork and converted into the same `Interrupt` exception (`Forked::Child.fork`):

```ruby
Signal.trap(:INT){::Thread.current.raise(Interrupt)}
Signal.trap(:TERM){::Thread.current.raise(Interrupt)}  # Same as SIGINT.
```

The fix in #59 (`Generic#interrupt` sets `@stopping = true`) therefore covers a single `SIGTERM` to a `Hybrid` fork as well — it must drain the inner threads and exit, rather than respawning them forever (the inner container runs with `restart: true`, the default for `async-service` managed services).

This PR adds a regression test for the `SIGTERM` path so the equivalence is locked in and can't silently regress.

## Changes

- Refactors the existing single-`SIGINT` test into a shared helper.
- Exercises both `:INT` and `:TERM` via the helper.

## Verification

- Both tests pass with the fix.
- Both tests fail when `@stopping = true` is reverted in `Generic#interrupt`, confirming they are meaningful regression tests rather than false passes.
- Full suite: 170/170 passing.
