### PR TITLE
Fork children from a new thread

### DIFF
--- a/lib/async/container/forked.rb
+++ b/lib/async/container/forked.rb
@@ -101,23 +101,25 @@ module Async
 				def self.fork(**options)
 					# $stderr.puts fork: caller
 					self.new(**options) do |process|
-						::Process.fork do
-							# We use `Thread.current.raise(...)` so that exceptions are filtered through `Thread.handle_interrupt` correctly.
-							Signal.trap(:INT){::Thread.current.raise(Interrupt)}
-							Signal.trap(:TERM){::Thread.current.raise(Interrupt)}  # Same as SIGINT.
-							Signal.trap(:HUP){::Thread.current.raise(Restart)}
-							
-							# This could be a configuration option:
-							::Thread.handle_interrupt(SignalException => :immediate) do
-								yield Instance.for(process)
-							rescue Interrupt
-								# Graceful exit.
-							rescue Exception => error
-								Console.error(self, error)
+						::Thread.new do
+							::Process.fork do
+								# We use `Thread.current.raise(...)` so that exceptions are filtered through `Thread.handle_interrupt` correctly.
+								Signal.trap(:INT){::Thread.current.raise(Interrupt)}
+								Signal.trap(:TERM){::Thread.current.raise(Interrupt)}  # Same as SIGINT.
+								Signal.trap(:HUP){::Thread.current.raise(Restart)}
 								
-								exit!(1)
+								# This could be a configuration option:
+								::Thread.handle_interrupt(SignalException => :immediate) do
+									yield Instance.for(process)
+								rescue Interrupt
+									# Graceful exit.
+								rescue Exception => error
+									Console.error(self, error)
+									
+									exit!(1)
+								end
 							end
-						end
+						end.value
 					end
 				end
 				

--- a/releases.md
+++ b/releases.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-  - **Changed**: Forked containers now fork child processes from a short-lived thread, reducing inherited scheduler and parent stack state in children.
+  - Forked containers now fork child processes from a short-lived thread, reducing inherited scheduler and parent stack state in children.
 
 ## v0.35.1
 

--- a/releases.md
+++ b/releases.md
@@ -1,5 +1,9 @@
 # Releases
 
+## Unreleased
+
+  - **Changed**: Forked containers now fork child processes from a short-lived thread, reducing inherited scheduler and parent stack state in children.
+
 ## v0.35.1
 
   - **Fixed**: `Hybrid` container now stops on interrupt instead of restarting indefinitely.


### PR DESCRIPTION
## Summary

- Fork container children from a short-lived Ruby thread using `Thread.new { Process.fork { ... } }.value`.
- Leave the existing container architecture, waiting logic, and signal handling otherwise unchanged.

## Testing

- Ruby 4.0: focused Async::Service policy/managed-service tests passed against this branch, with direct `Sus::Fixtures::Async::SchedulerContext` added locally around the two affected tests.
- Ruby 3.3.10: focused Async::Service policy/managed-service tests passed against this branch with the same local direct `SchedulerContext` edits.

Note: I also tried the full async-container suite under Ruby 3.3.10 on this branch. It was still waiting in an existing container fixture path after roughly 90 seconds, so I interrupted it rather than expanding the scope of this PR.