### PR TITLE
Add scheduler context container tests

### DIFF
--- a/fixtures/async/container/a_container.rb
+++ b/fixtures/async/container/a_container.rb
@@ -73,6 +73,71 @@ module Async
 				end
 			end
 			
+			with "Async{}" do
+				it "can wait inside an Async task after spawning outside Async" do
+					input, output = IO.pipe
+					
+					container.spawn do
+						output.write(".")
+					end
+					
+					Async do
+						container.wait
+					end.wait
+					
+					output.close
+					expect(input.read).to be == "."
+				end
+				
+				it "can spawn and wait inside the same Async task" do
+					input, output = IO.pipe
+					
+					Async do
+						container.spawn do
+							output.write(".")
+						end
+						
+						container.wait
+					end.wait
+					
+					output.close
+					expect(input.read).to be == "."
+				end
+				
+				it "can wait while a health monitor is active" do
+					container.spawn(health_check_timeout: 10.0) do |instance|
+						instance.ready!
+					end
+					
+					Async do |task|
+						task.with_timeout(2.0) do
+							container.wait
+						end
+					end.wait
+					
+					expect(container.statistics).to have_attributes(failures: be == 0)
+				end
+				
+				it "can start, wait until ready, and stop inside Sync" do
+					Sync do
+						begin
+							2.times do |i|
+								container.spawn(name: "worker #{i}") do |instance|
+									instance.ready!
+									sleep
+								end
+							end
+							
+							container.wait_until_ready
+							
+							expect(container.group.running).to have_attributes(size: be == 2)
+						ensure
+							container.stop if container.running?
+						end
+					end
+				end
+			end
+			
 			it "should be blocking" do
 				skip "Fiber.blocking? is not supported!" unless Fiber.respond_to?(:blocking?)
 				

--- a/gems.rb
+++ b/gems.rb
@@ -21,6 +21,7 @@ end
 
 group :test do
 	gem "sus"
+	gem "sus-fixtures-async"
 	gem "covered"
 	
 	gem "rubocop"

--- a/test/async/container/forked.rb
+++ b/test/async/container/forked.rb
@@ -7,8 +7,11 @@
 require "async/container/best"
 require "async/container/forked"
 require "async/container/a_container"
+require "sus/fixtures/async/scheduler_context"
 
 describe Async::Container::Forked do
+	include Sus::Fixtures::Async::SchedulerContext
+	
 	let(:container) {subject.new}
 	
 	it_behaves_like Async::Container::AContainer

--- a/test/async/container/hybrid.rb
+++ b/test/async/container/hybrid.rb
@@ -6,8 +6,11 @@
 require "async/container/hybrid"
 require "async/container/best"
 require "async/container/a_container"
+require "sus/fixtures/async/scheduler_context"
 
 describe Async::Container::Hybrid do
+	include Sus::Fixtures::Async::SchedulerContext
+	
 	it_behaves_like Async::Container::AContainer
 	
 	it "should be multiprocess" do

--- a/test/async/container/policy.rb
+++ b/test/async/container/policy.rb
@@ -5,8 +5,11 @@
 
 require "async/container/policy"
 require "async/container/best"
+require "sus/fixtures/async/scheduler_context"
 
 describe Async::Container::Policy do
+	include Sus::Fixtures::Async::SchedulerContext
+	
 	let(:policy) {subject.new}
 	
 	with "interface" do
@@ -232,6 +235,37 @@ describe Async::Container::Policy do
 			expect(exits.size).to be == 1
 			expect(exits.first).to have_keys(name: be == "failing-worker", success: be_falsey)
 			expect(container.statistics.failures).to be == 1
+		end
+		
+		it "can stop the container from child_exit" do
+			stop_policy = Class.new(Async::Container::Policy) do
+				def initialize
+					@stop_count = 0
+				end
+				
+				attr :stop_count
+				
+				def child_exit(container, child, status, name:, key:, **options)
+					unless container.stopping?
+						@stop_count += 1
+						container.stop
+					end
+				end
+			end.new
+			
+			container = Async::Container.best_container_class.new(policy: stop_policy)
+			
+			3.times do |i|
+				container.spawn(name: "worker-#{i}") do |instance|
+					instance.ready!
+					exit(1)
+				end
+			end
+			
+			container.wait
+			
+			expect(stop_policy.stop_count).to be == 1
+			expect(container).not.to be(:running?)
 		end
 		
 		it "invokes callbacks for multiple children" do

--- a/test/async/container/threaded.rb
+++ b/test/async/container/threaded.rb
@@ -5,8 +5,11 @@
 
 require "async/container/threaded"
 require "async/container/a_container"
+require "sus/fixtures/async/scheduler_context"
 
 describe Async::Container::Threaded do
+	include Sus::Fixtures::Async::SchedulerContext
+	
 	it_behaves_like Async::Container::AContainer
 	
 	it "should not be multiprocess" do


### PR DESCRIPTION
## Summary

- Add scheduler-context coverage for containers started and waited inside Async/Sync.
- Cover Forked, Threaded, and Hybrid shared container behavior.
- Add policy regression coverage for stopping a container from child_exit.
- Add sus-fixtures-async as a test dependency.

## Testing

- PATH=/Users/samuel/.local/state/tec/toolchain/base_profile/bin:$PATH bundle exec sus --verbose test/async/container/forked.rb test/async/container/threaded.rb test/async/container/hybrid.rb test/async/container/policy.rb
- PATH=/Users/samuel/.local/state/tec/toolchain/base_profile/bin:$PATH bundle exec sus --verbose