### PR TITLE
Honor configured graceful timeout in controller

### DIFF
--- a/lib/async/container/controller.rb
+++ b/lib/async/container/controller.rb
@@ -12,6 +12,18 @@ require_relative "policy"
 
 module Async
 	module Container
+		# The default graceful stop policy for controllers.
+		GRACEFUL_STOP = ENV.fetch("ASYNC_CONTAINER_GRACEFUL_STOP", "true").then do |value|
+			case value
+			when "true"
+				true # Default timeout for graceful termination.
+			when "false"
+				false # Immediately kill the processes.
+			else
+				value.to_f
+			end
+		end
+		
 		# Manages the life-cycle of one or more containers in order to support a persistent system.
 		# e.g. a web server, job server or some other long running system.
 		class Controller
@@ -23,7 +35,7 @@ module Async
 			
 			# Initialize the controller.
 			# @parameter notify [Notify::Client] A client used for process readiness notifications.
-			def initialize(notify: Notify.open!, container_class: Container, graceful_stop: true)
+			def initialize(notify: Notify.open!, container_class: Container, graceful_stop: GRACEFUL_STOP)
 				@notify = notify
 				@container_class = container_class
 				@graceful_stop = graceful_stop

--- a/lib/async/container/group.rb
+++ b/lib/async/container/group.rb
@@ -10,19 +10,7 @@ require_relative "error"
 
 module Async
 	module Container
-		# The default timeout for terminating processes, before escalating to killing.
-		GRACEFUL_TIMEOUT = ENV.fetch("ASYNC_CONTAINER_GRACEFUL_TIMEOUT", "true").then do |value|
-			case value
-			when "true"
-				true # Default timeout for graceful termination.
-			when "false"
-				false # Immediately kill the processes.
-			else
-				value.to_f
-			end
-		end
-		
-		# The default timeout for graceful termination.
+		# The default timeout for graceful termination, used when the `graceful` argument is true.
 		DEFAULT_GRACEFUL_TIMEOUT = 10.0
 		
 		# Manages a group of running processes.
@@ -163,7 +151,7 @@ module Async
 			# If `graceful` is false, skip the SIGINT phase and go directly to SIGKILL.
 			#
 			# @parameter graceful [Boolean | Numeric] Whether to send SIGINT first or skip directly to SIGKILL.
-			def stop(graceful = GRACEFUL_TIMEOUT)
+			def stop(graceful = true)
 				Console.debug(self, "Stopping all processes...", graceful: graceful)
 				
 				# If a timeout is specified, interrupt the children first:

--- a/releases.md
+++ b/releases.md
@@ -1,5 +1,9 @@
 # Releases
 
+## Unreleased
+
+  - Rename `ASYNC_CONTAINER_GRACEFUL_TIMEOUT` to `ASYNC_CONTAINER_GRACEFUL_STOP` and apply it at the controller level as `GRACEFUL_STOP`. `Group#stop` now only applies the shutdown policy it is given.
+
 ## v0.36.0
 
   - Forked containers now fork child processes from a short-lived thread, reducing inherited scheduler and parent stack state in children.

--- a/test/async/container/controller.rb
+++ b/test/async/container/controller.rb
@@ -17,6 +17,33 @@ describe Async::Container::Controller do
 		end
 	end
 	
+	with "#graceful_stop" do
+		def read_graceful_stop(value)
+			command = [
+				"bundle", "exec", "ruby", "-Ilib", "-e",
+				"require 'async/container/controller'; puts Async::Container::Controller.new(notify: nil).graceful_stop.inspect"
+			]
+			
+			output = IO.popen({"ASYNC_CONTAINER_GRACEFUL_STOP" => value}, command, &:read)
+			
+			expect($?.success?).to be == true
+			
+			return output
+		end
+		
+		it "uses the configured graceful timeout by default" do
+			output = read_graceful_stop("0.001")
+			
+			expect(output).to be == "0.001\n"
+		end
+		
+		it "can disable graceful stop by default" do
+			output = read_graceful_stop("false")
+			
+			expect(output).to be == "false\n"
+		end
+	end
+	
 	with "#reload" do
 		it "can reuse keyed child" do
 			input, output = IO.pipe


### PR DESCRIPTION
## Summary

- Default `Async::Container::Controller#initialize` to `GRACEFUL_TIMEOUT` instead of literal `true`.
- Add a regression test proving `ASYNC_CONTAINER_GRACEFUL_TIMEOUT` controls the controller default in a fresh process.

This complements socketry/async-service@3b2c234, which made `Async::Service::Controller#stop` honor inherited `@graceful_stop`. Without this lower-layer default, async-service still inherits literal `true` unless callers explicitly pass `graceful_stop:`.

## Tests

- `bundle exec sus test/async/container/controller.rb`
- `bundle exec sus`
