### PR TITLE
Document child signal handling

### DIFF
--- a/lib/async/container/forked.rb
+++ b/lib/async/container/forked.rb
@@ -101,6 +101,7 @@ module Async
 				def self.fork(**options)
 					# $stderr.puts fork: caller
 					self.new(**options) do |process|
+						# Fork from `Thread.new` so the child does not inherit the parent fiber scheduler or the current caller's fiber stack. Only this short-lived thread is copied into the child process:
 						::Thread.new do
 							::Process.fork do
 								# We use `Thread.current.raise(...)` so that exceptions are filtered through `Thread.handle_interrupt` correctly.
@@ -108,7 +109,7 @@ module Async
 								Signal.trap(:TERM){::Thread.current.raise(Interrupt)}  # Same as SIGINT.
 								Signal.trap(:HUP){::Thread.current.raise(Restart)}
 								
-								# This could be a configuration option:
+								# Reset `SignalException` delivery because CRuby inherits the `Thread.handle_interrupt` mask stack across `Thread.new`. Async deliberately masks signal exceptions, and the signal traps above should be delivered promptly:
 								::Thread.handle_interrupt(SignalException => :immediate) do
 									yield Instance.for(process)
 								rescue Interrupt

--- a/lib/async/container/threaded.rb
+++ b/lib/async/container/threaded.rb
@@ -114,7 +114,7 @@ module Async
 				def self.fork(**options)
 					self.new(**options) do |thread|
 						::Thread.new do
-							# This could be a configuration option (see forked implementation too):
+							# Reset `SignalException` delivery because CRuby inherits the `Thread.handle_interrupt` mask stack across `Thread.new`. Async deliberately masks signal exceptions, and signal-driven thread control should be delivered promptly:
 							::Thread.handle_interrupt(SignalException => :immediate) do
 								yield Instance.for(thread)
 							end

--- a/test/async/container/channel.rb
+++ b/test/async/container/channel.rb
@@ -30,6 +30,32 @@ describe Async::Container::Channel do
 		expect(channel.receive).to be_nil
 	end
 	
+	with "#close" do
+		it "can close more than once" do
+			channel.close
+			
+			expect do
+				channel.close
+			end.not.to raise_exception
+		end
+		
+		it "can close the input end after it was already closed" do
+			channel.in.close
+			
+			expect do
+				channel.close_read
+			end.not.to raise_exception
+		end
+		
+		it "can close the output end after it was already closed" do
+			channel.out.close
+			
+			expect do
+				channel.close_write
+			end.not.to raise_exception
+		end
+	end
+	
 	with "timeout" do
 		let(:channel) {subject.new(timeout: 0.001)}
 		


### PR DESCRIPTION
## Summary

- Document why forked children are created from a short-lived `Thread.new`.
- Document why child execution resets `SignalException` handling after `Thread.new`.
- Add regression coverage for the existing idempotent `Channel#close` behavior.

## Testing

- `bundle exec sus --verbose test/async/container/channel.rb`
- `bundle exec rubocop lib/async/container/channel.rb test/async/container/channel.rb`
- `bundle exec sus --verbose`