### PR TITLE
Adopt async-signals graceful defaults

### DIFF
--- a/async-container.gemspec
+++ b/async-container.gemspec
@@ -25,4 +25,5 @@ Gem::Specification.new do |spec|
 	spec.required_ruby_version = ">= 3.3"
 	
 	spec.add_dependency "async", "~> 2.22"
+	spec.add_dependency "async-signals", "~> 0.6"
 end

--- a/lib/async/container/controller.rb
+++ b/lib/async/container/controller.rb
@@ -10,6 +10,9 @@ require_relative "statistics"
 require_relative "notify"
 require_relative "policy"
 
+# This sets up graceful handling of SIGINT and SIGTERM.
+require "async/signals/graceful"
+
 module Async
 	module Container
 		# The default graceful stop policy for controllers.

--- a/test/async/container.rb
+++ b/test/async/container.rb
@@ -4,8 +4,23 @@
 # Copyright, 2017-2025, by Samuel Williams.
 
 require "async/container"
+require "open3"
+require "rbconfig"
 
 describe Async::Container do
+	def ruby(script)
+		::Open3.capture3(::RbConfig.ruby, "-Ilib", "-e", script)
+	end
+	
+	def expect_success(script)
+		stdout, stderr, status = ruby(script)
+		
+		expect(status).to be(:success?)
+		expect(stderr).to be == ""
+		
+		return stdout
+	end
+	
 	with ".processor_count" do
 		it "can get processor count" do
 			expect(Async::Container.processor_count).to be >= 1
@@ -32,6 +47,46 @@ describe Async::Container do
 		it "can get best container class" do
 			expect(container).not.to be_nil
 			container.stop
+		end
+	end
+	
+	with "graceful signal defaults" do
+		it "installs graceful SIGINT handling" do
+			stdout = expect_success(<<~RUBY)
+				require "async/container"
+				
+				begin
+					::Thread.handle_interrupt(::Interrupt => :never) do
+						::Process.kill(:INT, ::Process.pid)
+						puts "inner"
+					end
+					
+					sleep 1
+				rescue ::Interrupt
+					puts "outer"
+				end
+			RUBY
+			
+			expect(stdout).to be == "inner\nouter\n"
+		end
+		
+		it "installs graceful SIGTERM handling" do
+			stdout = expect_success(<<~RUBY)
+				require "async/container"
+				
+				begin
+					::Thread.handle_interrupt(::Interrupt => :never) do
+						::Process.kill(:TERM, ::Process.pid)
+						puts "inner"
+					end
+					
+					sleep 1
+				rescue ::Interrupt
+					puts "outer"
+				end
+			RUBY
+			
+			expect(stdout).to be == "inner\nouter\n"
 		end
 	end
 	


### PR DESCRIPTION
Installs graceful `SIGINT`/`SIGTERM` handling at load time via `async-signals`.

Ruby's built-in handling for `SIGINT` can bypass `Thread.handle_interrupt`, which makes graceful shutdown unreliable for event loops and anything that needs to defer interruption while cleaning up. Requiring `async/signals/graceful` maps both `SIGINT` and `SIGTERM` to `Interrupt` so they follow the same graceful shutdown path (only replacing the default handler, never overriding one a user already set).

See <https://bugs.ruby-lang.org/issues/22133> for background.

## Changes

- `async-container.gemspec`: add `async-signals ~> 0.6` dependency.
- `lib/async/container.rb`: `require "async/signals/graceful"`.
- `test/async/container.rb`: add subprocess-based behavioral tests verifying `SIGINT`/`SIGTERM` are delivered through `Thread.handle_interrupt`.

This is the first in a series of stacked PRs breaking down the larger controller/signals rework. It stands alone and is backwards compatible: no existing tests were modified, only added.