### PR TITLE
Make Controller#start idempotent

### DIFF
--- a/lib/async/container/controller.rb
+++ b/lib/async/container/controller.rb
@@ -120,13 +120,18 @@ module Async
 			end
 			
 			# Start the container unless it's already running.
+			# @returns [Boolean] Whether a new container was started.
 			def start
 				unless @container
 					Console.info(self, "Controller starting...")
 					self.restart
+					
+					Console.info(self, "Controller started.")
+					
+					return true
 				end
 				
-				Console.info(self, "Controller started.")
+				return false
 			end
 			
 			# Stop the container if it's running.

--- a/test/async/container/controller.rb
+++ b/test/async/container/controller.rb
@@ -139,6 +139,21 @@ describe Async::Container::Controller do
 			expect(controller.container).to be_nil
 		end
 		
+		it "doesn't restart a container if it's already running" do
+			expect(controller).to receive(:setup)
+			
+			expect(controller.start).to be == true
+			expect(controller).to be(:running?)
+			
+			container = controller.container
+			
+			# Starting again is idempotent: it returns false and the container is not replaced.
+			expect(controller.start).to be == false
+			expect(controller.container).to be_equal(container)
+		ensure
+			controller.stop
+		end
+		
 		it "can spawn a reactor" do
 			def controller.setup(container)
 				container.async do |task|


### PR DESCRIPTION
`Controller#start` now returns a boolean so callers (and tests) can tell whether it actually started a container:

- `true` — a new container was started.
- `false` — a container was already running (no-op).

The original guard (`unless @container`) and behavior are unchanged; this just surfaces the outcome as a return value.

## Test

Drives a real container: asserts the first `start` returns `true`, a second `start` returns `false`, the container object is unchanged, and `setup` runs only once. Additive — no existing tests modified.