### PR TITLE
Make policy stop test deterministic

### DIFF
--- a/test/async/container/policy.rb
+++ b/test/async/container/policy.rb
@@ -254,13 +254,25 @@ describe Async::Container::Policy do
 			end.new
 			
 			container = Async::Container.best_container_class.new(policy: stop_policy)
+			trigger = IO.pipe
 			
 			3.times do |i|
 				container.spawn(name: "worker-#{i}") do |instance|
 					instance.ready!
-					exit(1)
+					
+					# Only the first worker exits, and only once all workers are ready, so exactly one `child_exit` drives the stop. Otherwise multiple simultaneous exits can race the `stopping?` check and inflate `stop_count`.
+					if i.zero?
+						trigger.first.gets
+						exit(1)
+					else
+						sleep
+					end
 				end
 			end
+			
+			container.wait_until_ready
+			
+			trigger.last.puts("exit")
 			
 			container.wait
 			


### PR DESCRIPTION
The `"can stop the container from child_exit"` test was racy. All three workers called `exit(1)` immediately, so multiple `child_exit` callbacks could fire before `container.stop` took effect. The policy guards with `unless container.stopping?`, but that's a check-then-act race — several children can each observe `stopping? == false` and increment `stop_count`, making the `stop_count == 1` assertion flaky.

## Fix

Only the first worker exits, and only after all workers are ready (coordinated via a pipe). The others `sleep`. This guarantees exactly one `child_exit` drives the stop, so `stop_count` is deterministically `1`.

Test-only, no library change. Verified stable across repeated runs.