### PR TITLE
Add tests for controller restart behaviour.

### DIFF
--- a/test/async/container/controller.rb
+++ b/test/async/container/controller.rb
@@ -84,6 +84,49 @@ describe Async::Container::Controller do
 		end
 	end
 	
+	with "#restart" do
+		it "replaces the running container with a new one" do
+			def controller.setup(container)
+				container.spawn do |instance|
+					instance.ready!
+					sleep
+				end
+			end
+			
+			controller.start
+			first = controller.container
+			
+			expect(first).not.to be_nil
+			expect(controller).to be(:running?)
+			
+			# A restart is a blue-green swap: a new container is created and the old one is stopped.
+			controller.restart
+			
+			expect(controller.container).not.to be_equal(first)
+			expect(controller).to be(:running?)
+		ensure
+			controller.stop(false)
+		end
+		
+		it "starts a new container if not already running" do
+			def controller.setup(container)
+				container.spawn do |instance|
+					instance.ready!
+					sleep
+				end
+			end
+			
+			expect(controller).not.to be(:running?)
+			
+			controller.restart
+			
+			expect(controller).to be(:running?)
+			expect(controller.container).not.to be_nil
+		ensure
+			controller.stop(false)
+		end
+	end
+	
 	with "notify" do
 		before do
 			@notify_server = Async::Container::Notify::Server.open


### PR DESCRIPTION
Locks in the current `#restart` behaviour before refactoring signal/restart handling. Test-only, additive.

## Coverage added (`with "#restart"`)

1. **Blue-green replace** — `restart` on a running controller creates a new container and swaps it in (the container object is replaced), stopping the old one.
2. **Start-when-not-running** — `restart` starts a container if none is running.

## Note

Restart is a *replace* operation (blue-green): children are recreated wholesale, so restart does not propagate into live children/sub-controllers. Accordingly this PR intentionally does **not** pin any cross-thread `Thread#raise(Restart)` propagation behaviour — that path (`Child#restart!`) is a candidate for removal, and propagation semantics belong to `reload`, not `restart`.

Reload reconciliation coverage (add/remove keyed children) is handled in a separate PR.