### PR TITLE
Fork children from a clean fiber

### DIFF
--- a/async-container.gemspec
+++ b/async-container.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |spec|
 	
 	spec.required_ruby_version = ">= 3.3"
 	
-	spec.add_dependency "async", "~> 2.22"
+	spec.add_dependency "async", "~> 2.44"
 end

--- a/lib/async/container/forked.rb
+++ b/lib/async/container/forked.rb
@@ -102,8 +102,7 @@ module Async
 					# $stderr.puts fork: caller
 					self.new(**options) do |process|
 						# CRuby makes the currently executing fiber the root fiber in the child process and clears its resuming fiber, so the caller's stack can be collected without forking from a separate native thread:
-						# This must remain a non-blocking fiber so resuming it does not register a blocked operation with an active fiber scheduler.
-						::Fiber.new do
+						::Fiber.new(blocking: true) do
 							::Process.fork do
 								# We use `Thread.current.raise(...)` so that exceptions are filtered through `Thread.handle_interrupt` correctly.
 								Signal.trap(:INT){::Thread.current.raise(Interrupt)}

--- a/lib/async/container/forked.rb
+++ b/lib/async/container/forked.rb
@@ -102,7 +102,8 @@ module Async
 					# $stderr.puts fork: caller
 					self.new(**options) do |process|
 						# CRuby makes the currently executing fiber the root fiber in the child process and clears its resuming fiber, so the caller's stack can be collected without forking from a separate native thread:
-						::Fiber.new(blocking: true) do
+						# This must remain a non-blocking fiber so resuming it does not register a blocked operation with an active fiber scheduler.
+						::Fiber.new do
 							::Process.fork do
 								# We use `Thread.current.raise(...)` so that exceptions are filtered through `Thread.handle_interrupt` correctly.
 								Signal.trap(:INT){::Thread.current.raise(Interrupt)}

--- a/lib/async/container/forked.rb
+++ b/lib/async/container/forked.rb
@@ -101,7 +101,8 @@ module Async
 				def self.fork(**options)
 					# $stderr.puts fork: caller
 					self.new(**options) do |process|
-						::Thread.new do
+						# CRuby makes the currently executing fiber the root fiber in the child process and clears its resuming fiber, so the caller's stack can be collected without forking from a separate native thread:
+						::Fiber.new(blocking: true) do
 							::Process.fork do
 								# We use `Thread.current.raise(...)` so that exceptions are filtered through `Thread.handle_interrupt` correctly.
 								Signal.trap(:INT){::Thread.current.raise(Interrupt)}
@@ -119,7 +120,7 @@ module Async
 									exit!(1)
 								end
 							end
-						end.value
+						end.resume
 					end
 				end
 				

--- a/releases.md
+++ b/releases.md
@@ -1,5 +1,9 @@
 # Releases
 
+## Unreleased
+
+  - Fork child processes from a clean fiber stack rather than a short-lived native thread, preserving child garbage collection while improving compatibility with native libraries.
+
 ## v0.37.0
 
   - Rename `ASYNC_CONTAINER_GRACEFUL_TIMEOUT` to `ASYNC_CONTAINER_GRACEFUL_STOP` and apply it at the controller level as `GRACEFUL_STOP`. `Group#stop` now only applies the shutdown policy it is given.

--- a/test/async/container/forked.rb
+++ b/test/async/container/forked.rb
@@ -20,26 +20,26 @@ describe Async::Container::Forked do
 			3.times do
 				GC.start(full_mark: true, immediate_sweep: true)
 			end
-			
+				
 			output.puts(weak_marker.weakref_alive? ? "alive" : "collected")
 		ensure
 			output.close
 		end
 	end
-	
+		
 	it_behaves_like Async::Container::AContainer
-	
+		
 	it "forks with a clean child fiber stack" do
 		input, output = IO.pipe
 		marker = Object.new
 		weak_marker = WeakRef.new(marker)
-		
+			
 		child = fork_with_weak_marker(weak_marker, output)
 		output.close
-		
+			
 		expect(input.read).to be == "collected\n"
 		expect(child.wait).to be(:success?)
-		
+			
 		# Keep the marker live on the caller's stack until after the child exits:
 		marker.object_id
 	ensure
@@ -47,40 +47,40 @@ describe Async::Container::Forked do
 		output&.close
 		child&.wait
 	end
-	
+		
 	it "can restart child" do
 		trigger = IO.pipe
 		pids = IO.pipe
-		
+			
 		thread = Thread.new do
 			container.async(restart: true) do
 				trigger.first.gets
 				pids.last.puts Process.pid.to_s
 			end
-			
+				
 			container.wait
 		end
-		
+			
 		3.times do
 			trigger.last.puts "die"
 			_child_pid = pids.first.gets
 		end
-		
+			
 		thread.kill
 		thread.join
-		
+			
 		expect(container.statistics.spawns).to be == 1
 		expect(container.statistics.restarts).to be == 2
 	end
-	
+		
 	it "can handle interrupts" do
 		finished = IO.pipe
 		interrupted = IO.pipe
-		
+			
 		container.spawn(restart: true) do |instance|
 			Thread.handle_interrupt(Interrupt => :never) do
 				instance.ready!
-				
+					
 				finished.first.gets
 			rescue ::Interrupt
 				interrupted.last.puts "incorrectly interrupted"
@@ -88,18 +88,18 @@ describe Async::Container::Forked do
 		rescue ::Interrupt
 			interrupted.last.puts "correctly interrupted"
 		end
-		
+			
 		container.wait_until_ready
-		
+			
 		container.group.interrupt
 		sleep(0.001)
 		finished.last.puts "finished"
-		
+			
 		expect(interrupted.first.gets).to be == "correctly interrupted\n"
-		
+			
 		container.stop
 	end
-	
+		
 	it "should be multiprocess" do
 		expect(subject).to be(:multiprocess?)
 	end

--- a/test/async/container/forked.rb
+++ b/test/async/container/forked.rb
@@ -8,13 +8,45 @@ require "async/container/best"
 require "async/container/forked"
 require "async/container/a_container"
 require "sus/fixtures/async/scheduler_context"
+require "weakref"
 
 describe Async::Container::Forked do
 	include Sus::Fixtures::Async::SchedulerContext
 	
 	let(:container) {subject.new}
 	
+	def fork_with_weak_marker(weak_marker, output)
+		Async::Container::Forked::Child.fork do
+			3.times do
+				GC.start(full_mark: true, immediate_sweep: true)
+			end
+			
+			output.puts(weak_marker.weakref_alive? ? "alive" : "collected")
+		ensure
+			output.close
+		end
+	end
+	
 	it_behaves_like Async::Container::AContainer
+	
+	it "forks with a clean child fiber stack" do
+		input, output = IO.pipe
+		marker = Object.new
+		weak_marker = WeakRef.new(marker)
+		
+		child = fork_with_weak_marker(weak_marker, output)
+		output.close
+		
+		expect(input.read).to be == "collected\n"
+		expect(child.wait).to be(:success?)
+		
+		# Keep the marker live on the caller's stack until after the child exits:
+		marker.object_id
+	ensure
+		input&.close
+		output&.close
+		child&.wait
+	end
 	
 	it "can restart child" do
 		trigger = IO.pipe

--- a/test/async/container/hybrid.rb
+++ b/test/async/container/hybrid.rb
@@ -16,11 +16,11 @@ describe Async::Container::Hybrid do
 	it "should be multiprocess" do
 		expect(subject).to be(:multiprocess?)
 	end
-	
+		
 	it "forcefully stops the inner threaded container on exit" do
 		stop_arguments = []
 		interrupt_count = 0
-		
+			
 		threaded_class = Class.new
 		threaded_class.define_method(:run) do |**options, &block|
 			self
@@ -30,7 +30,7 @@ describe Async::Container::Hybrid do
 		threaded_class.define_method(:wait) do
 			@wait_count ||= 0
 			@wait_count += 1
-			
+				
 			raise Interrupt if @wait_count == 1
 		end
 		threaded_class.define_method(:interrupt) do
@@ -39,32 +39,32 @@ describe Async::Container::Hybrid do
 		threaded_class.define_method(:stop) do |graceful = true|
 			stop_arguments << graceful
 		end
-		
+			
 		container_class = Class.new(subject) do
 			def spawn(**options, &block)
 				instance = Object.new
 				def instance.ready!
 				end
-				
+					
 				block.call(instance)
 			end
 		end
-		
+			
 		original_threaded = Async::Container.send(:remove_const, :Threaded)
 		Async::Container.const_set(:Threaded, threaded_class)
-		
+			
 		container = container_class.new
 		container.run(count: 1, forks: 1, threads: 1) do |instance|
 			# No-op.
 		end
-		
+			
 		expect(interrupt_count).to be == 1
 		expect(stop_arguments).to be == [false]
 	ensure
 		Async::Container.send(:remove_const, :Threaded)
 		Async::Container.const_set(:Threaded, original_threaded)
 	end
-	
+		
 	# https://github.com/socketry/async-container/issues/58
 	#
 	# SIGINT and SIGTERM are intentionally equivalent: both are trapped in the fork and converted into `Interrupt` (see `Forked::Child.fork`), so a single signal of either kind must drain the inner threads and exit, rather than respawning them forever (the inner container has `restart: true`, the default for `async-service` managed services).
@@ -73,20 +73,20 @@ describe Async::Container::Hybrid do
 		fork_pid = nil
 		exited = false
 		container = subject.new
-		
+			
 		container.run(count: 1, forks: 1, threads: 1, restart: true) do |instance|
 			pids.last.puts(Process.pid.to_s)
 			instance.ready!
 			sleep
 		end
-		
+			
 		container.wait_until_ready
-		
+			
 		fork_pid = Integer(pids.first.gets)
-		
+			
 		# Mimic a single signal delivered to the fork (e.g. memory-based worker recycling):
 		Process.kill(signal, fork_pid)
-		
+			
 		# The fork must drain its inner threads and exit, rather than respawning them forever:
 		8.times do
 			reaped, _status = Process.waitpid2(fork_pid, Process::WNOHANG)
@@ -99,18 +99,18 @@ describe Async::Container::Hybrid do
 			exited = true
 			break
 		end
-		
+			
 		expect(exited).to be == true
 	ensure
 		Process.kill(:KILL, fork_pid) if fork_pid && !exited
 		container&.stop
 		pids&.each(&:close)
 	end
-	
+		
 	it "exits the fork on a single SIGINT even when the inner container has restart: true" do
 		exits_fork_on_single_signal(:INT)
 	end
-	
+		
 	it "exits the fork on a single SIGTERM even when the inner container has restart: true" do
 		exits_fork_on_single_signal(:TERM)
 	end

--- a/test/async/container/notify.rb
+++ b/test/async/container/notify.rb
@@ -23,25 +23,25 @@ describe Async::Container::Notify do
 		# Custom fields are transmitted as strings per the systemd protocol
 		expect(message).to be == {hello: "world", count: "42"}
 	end
-	
+		
 	with "#ready!" do
 		it "should send message" do
 			begin
 				context = server.bind
-				
+					
 				pid = fork do
 					client.ready!
 				end
-				
+					
 				messages = []
-				
+					
 				Sync do
 					context.receive do |message, address|
 						messages << message
 						break
 					end
 				end
-				
+					
 				expect(messages.last).to have_keys(
 					ready: be == true
 				)
@@ -51,27 +51,27 @@ describe Async::Container::Notify do
 			end
 		end
 	end
-	
+		
 	with "#healthy!" do
 		it "sends healthy message" do
 			context = server.bind
-			
+				
 			client.healthy!
-			
+				
 			message = context.receive
-			
+				
 			expect(message).to have_keys(
 				healthy: be == true
 			)
 		end
-		
+			
 		it "sends healthy message with additional details" do
 			context = server.bind
-			
+				
 			client.healthy!(status: "All systems operational", uptime: 3600)
-			
+				
 			message = context.receive
-			
+				
 			expect(message).to have_keys(
 				healthy: be == true,
 				status: be == "All systems operational",
@@ -79,49 +79,49 @@ describe Async::Container::Notify do
 			)
 		end
 	end
-	
+		
 	with "#send" do
 		it "sends message" do
 			context = server.bind
-			
+				
 			client.send(hello: "world")
-			
+				
 			message = context.receive
-			
+				
 			expect(message).to be == {hello: "world"}
 		end
-		
+			
 		it "fails if the message is too big" do
 			context = server.bind
-			
+				
 			expect do
 				client.send(test: "x" * (subject::Socket::MAXIMUM_MESSAGE_SIZE+1))
 			end.to raise_exception(ArgumentError, message: be =~ /Message length \d+ exceeds \d+/)
 		end
 	end
-	
+		
 	with "#stopping!" do
 		it "sends stopping message" do
 			context = server.bind
-			
+				
 			client.stopping!
-			
+				
 			message = context.receive
-			
+				
 			expect(message).to have_keys(
 				stopping: be == true
 			)
 		end
 	end
-	
+		
 	with "#error!" do
 		it "sends error message" do
 			context = server.bind
-			
+				
 			client.error!("Boom!")
-			
+				
 			message = context.receive
-			
+				
 			expect(message).to have_keys(
 				status: be == "Boom!",
 				errno: be == -1,


### PR DESCRIPTION
## Summary

- Replace the short-lived native thread used for `Process.fork` with a blocking Fiber.
- Keep fork on the caller's native thread for compatibility with native libraries such as gRPC.
- Preserve the clean child stack: CRuby promotes the current Fiber to the child root and clears its resuming Fiber after fork.
- Add a regression test proving objects retained only by the caller stack can be collected in the child.

CRuby behavior: https://bugs.ruby-lang.org/issues/15041

## Testing

- `ruby -Ilib .../sus test/async/container/forked.rb`
- 30 tests, 60 assertions passed.
- Ruby syntax and `git diff --check` passed.